### PR TITLE
Help Dialog's topic selector should no longer take up entire screen.

### DIFF
--- a/helpdialog.cpp
+++ b/helpdialog.cpp
@@ -25,7 +25,7 @@
 #include "pep.h"
 #include <QClipboard>
 #include <QDebug>
-
+const int HelpDialog::defaultHelpTreeWidth = 200;
 HelpDialog::HelpDialog(QWidget *parent) :
     QDialog(parent),
     ui(new Ui::HelpDialog)
@@ -46,6 +46,13 @@ HelpDialog::HelpDialog(QWidget *parent) :
     microcodeEditor = new MicrocodeEditor(this, false, true);
     ui->verticalLayout->insertWidget(0, microcodeEditor);
 
+    QList<int> list, list2;
+    list.append(HelpDialog::defaultHelpTreeWidth);
+    list.append(size().width()-HelpDialog::defaultHelpTreeWidth);
+    ui->splitter_3->setSizes(list);
+    list2.append(1);
+    list2.append(ui->helpCopyToMicrocodeButton->height()+10);
+    ui->helpSplitter->setSizes(list);
     leftHighlighter = new PepHighlighter(microcodeEditor->document());
 
     ui->helpTreeWidget->setFont(QFont(Pep::labelFont, Pep::labelFontSize));

--- a/helpdialog.h
+++ b/helpdialog.h
@@ -54,7 +54,7 @@ private:
 
     MicrocodeEditor *microcodeEditor;
     PepHighlighter *leftHighlighter;
-
+    static const int defaultHelpTreeWidth;
     enum Row {
         eUSINGPEP8CPU = 0,
         ePEP8REFERENCE = 1,


### PR DESCRIPTION
The help dialog's help selection widget should no longer take up the entire visible area